### PR TITLE
Settings dict now available in plugins.

### DIFF
--- a/plugin-test/service-check
+++ b/plugin-test/service-check
@@ -61,4 +61,5 @@ class ServiceCheck(SensuPluginCheck):
             self.ok("Overriding message")
 
 if __name__ == "__main__":
+    os.environ['SENSU_CONFIG_FILE'] = "plugin-test/service-check.json"
     f = ServiceCheck()

--- a/plugin-test/service-check.json
+++ b/plugin-test/service-check.json
@@ -1,0 +1,23 @@
+{
+    "checks": {
+        "check_nat": {
+            "command": "/etc/sensu/plugins/check-nat.py",
+            "interval": 300,
+            "subscribers": [ "master" ],
+            "occurrences": 3
+        }
+    },
+
+    "A":{
+        "nat1":"i-11",
+        "nat2":"i-22",
+        "rt":"rtb-33"
+    },
+
+    "B":{
+        "nat1":"i-111",
+        "nat2":"i-222",
+        "rt":"rtb-333"
+    }
+
+}

--- a/sensu_plugin/check.py
+++ b/sensu_plugin/check.py
@@ -33,4 +33,4 @@ class SensuPluginCheck(SensuPlugin):
             msg = ": {}".format(' '.join(str(message) for message in m))
 
         print("{} {}{}".format(self.check_name(),
-              self.plugin_info['status'], msg))
+            self.plugin_info['status'], msg))

--- a/sensu_plugin/check.py
+++ b/sensu_plugin/check.py
@@ -33,4 +33,4 @@ class SensuPluginCheck(SensuPlugin):
             msg = ": {}".format(' '.join(str(message) for message in m))
 
         print("{} {}{}".format(self.check_name(),
-            self.plugin_info['status'], msg))
+                               self.plugin_info['status'], msg))t

--- a/sensu_plugin/check.py
+++ b/sensu_plugin/check.py
@@ -33,4 +33,4 @@ class SensuPluginCheck(SensuPlugin):
             msg = ": {}".format(' '.join(str(message) for message in m))
 
         print("{} {}{}".format(self.check_name(),
-                               self.plugin_info['status'], msg))t
+                               self.plugin_info['status'], msg))

--- a/sensu_plugin/plugin.py
+++ b/sensu_plugin/plugin.py
@@ -23,7 +23,6 @@ ExitCode = namedtuple('ExitCode', ['OK', 'WARNING', 'CRITICAL', 'UNKNOWN'])
 class SensuPlugin(object):
     def __init__(self):
         self.settings = {}
-        self.tupl_list = []
         self.get_settings()
         self.plugin_info = {
             'check_name': None,
@@ -51,19 +50,21 @@ class SensuPlugin(object):
             self.settings[key[0]]=key[1]
 
     def get_settings(self):
-        config_file = '/etc/sensu/config.json'
-        config_file_path = '/etc/sensu/conf.d/'
+        config_files = ['/etc/sensu/config.json', '/etc/sensu/conf.d/']
 
-        if os.path.isfile(config_file):
-            with open(config_file) as f_handler:
-                self.get_json(f_handler)
-        else:
-            for dirs, sub_dirs, files in os.walk(config_file_path):
-                for f in files:
-                    f_path = config_file_path+f
-                    if f_path.endswith('.json'):
-                        with open(f_path) as f_handler:
-                            self.get_json(f_handler)
+        for config_file in config_files:
+            if os.path.isfile(config_file):
+                with open(config_file) as f_handler:
+                    self.get_json(f_handler)
+            elif os.path.isdir(config_file):
+                for dirs, sub_dirs, files in os.walk(config_file):
+                    for f in files:
+                        f_path = config_file+f
+                        if f_path.endswith('.json'):
+                            with open(f_path) as f_handler:
+                                self.get_json(f_handler)
+            else:
+                self.warning("Config files not found")
 
     def output(self, args):
         print("SensuPlugin: %s" % ' '.join(str(a) for a in args))
@@ -95,3 +96,4 @@ class SensuPlugin(object):
                   (sys.last_type, traceback.format_tb(sys.last_traceback)))
             sys.stdout.flush()
             os._exit(2)
+

--- a/sensu_plugin/plugin.py
+++ b/sensu_plugin/plugin.py
@@ -34,7 +34,6 @@ class SensuPlugin(object):
         self.exit_code = ExitCode(0, 1, 2, 3)
         for field in self.exit_code._fields:
             self.__make_dynamic(field)
-
         atexit.register(self.__exitfunction)
 
         self.parser = argparse.ArgumentParser()
@@ -63,8 +62,6 @@ class SensuPlugin(object):
                         if f_path.endswith('.json'):
                             with open(f_path) as f_handler:
                                 self.get_json(f_handler)
-            else:
-                self.warning("Config files not found")
 
     def output(self, args):
         print("SensuPlugin: %s" % ' '.join(str(a) for a in args))
@@ -96,4 +93,3 @@ class SensuPlugin(object):
                   (sys.last_type, traceback.format_tb(sys.last_traceback)))
             sys.stdout.flush()
             os._exit(2)
-

--- a/sensu_plugin/plugin.py
+++ b/sensu_plugin/plugin.py
@@ -23,7 +23,7 @@ ExitCode = namedtuple('ExitCode', ['OK', 'WARNING', 'CRITICAL', 'UNKNOWN'])
 class SensuPlugin(object):
     def __init__(self):
         self.settings = {}
-        self.config_files = ['/etc/sensu/config.json', '/etc/sensu/conf.d/']
+        self.config_files = []
         self.get_settings()
         self.plugin_info = {
             'check_name': None,
@@ -50,9 +50,13 @@ class SensuPlugin(object):
             self.settings[key[0]] = key[1]
 
     def get_settings(self):
-        if os.environ['SENSU_CONFIG_FILE']:
+        if 'SENSU_CONFIG_FILE' in os.environ:
             env_var = os.environ['SENSU_CONFIG_FILE']
             self.config_files.append(env_var)
+
+        else:
+            self.config_files.append('/etc/sensu/config.json')
+            self.config_files.append('/etc/sensu/conf.d/')
 
         for config_file in self.config_files:
             if os.path.isfile(config_file):
@@ -96,4 +100,3 @@ class SensuPlugin(object):
                   (sys.last_type, traceback.format_tb(sys.last_traceback)))
             sys.stdout.flush()
             os._exit(2)
-

--- a/sensu_plugin/plugin.py
+++ b/sensu_plugin/plugin.py
@@ -46,7 +46,7 @@ class SensuPlugin(object):
     def get_json(self, file_handler):
         all_data = json.load(file_handler)
         for key in all_data.iteritems():
-            self.settings[key[0]]=key[1]
+            self.settings[key[0]] = key[1]
 
     def get_settings(self):
         config_files = ['/etc/sensu/config.json', '/etc/sensu/conf.d/']
@@ -57,8 +57,8 @@ class SensuPlugin(object):
                     self.get_json(f_handler)
             elif os.path.isdir(config_file):
                 for dirs, sub_dirs, files in os.walk(config_file):
-                    for f in files:
-                        f_path = config_file+f
+                    for f_file in files:
+                        f_path = config_file+f_file
                         if f_path.endswith('.json'):
                             with open(f_path) as f_handler:
                                 self.get_json(f_handler)

--- a/sensu_plugin/plugin.py
+++ b/sensu_plugin/plugin.py
@@ -23,6 +23,7 @@ ExitCode = namedtuple('ExitCode', ['OK', 'WARNING', 'CRITICAL', 'UNKNOWN'])
 class SensuPlugin(object):
     def __init__(self):
         self.settings = {}
+        self.config_files = ['/etc/sensu/config.json', '/etc/sensu/conf.d/']
         self.get_settings()
         self.plugin_info = {
             'check_name': None,
@@ -49,9 +50,11 @@ class SensuPlugin(object):
             self.settings[key[0]] = key[1]
 
     def get_settings(self):
-        config_files = ['/etc/sensu/config.json', '/etc/sensu/conf.d/']
+        if os.environ['SENSU_CONFIG_FILE']:
+            env_var = os.environ['SENSU_CONFIG_FILE']
+            self.config_files.append(env_var)
 
-        for config_file in config_files:
+        for config_file in self.config_files:
             if os.path.isfile(config_file):
                 with open(config_file) as f_handler:
                     self.get_json(f_handler)
@@ -93,3 +96,4 @@ class SensuPlugin(object):
                   (sys.last_type, traceback.format_tb(sys.last_traceback)))
             sys.stdout.flush()
             os._exit(2)
+

--- a/sensu_plugin/plugin.py
+++ b/sensu_plugin/plugin.py
@@ -31,7 +31,7 @@ class SensuPlugin(object):
         self.settings = {}
         self._hook = ExitHook()
         self._hook.hook()
-        self.something()
+        self.get_settings()
         self.exit_code = ExitCode(0, 1, 2, 3)
         for field in self.exit_code._fields:
             self.__make_dynamic(field)
@@ -55,12 +55,7 @@ class SensuPlugin(object):
             if k != 'checks':
                 self.settings[k] = v
 
-    def something(self):
-        """
-        for subdir, dir, files in os.walk(file_path):
-        for file in files:
-        print subdir+'/'+file
-        """
+    def get_settings(self):
         # Check if config.json exists
         config_file = '/etc/sensu/config.json'
         config_file_path = '/etc/sensu/conf.d/'

--- a/sensu_plugin/plugin.py
+++ b/sensu_plugin/plugin.py
@@ -56,7 +56,7 @@ class SensuPlugin(object):
                 with open(config_file) as f_handler:
                     self.get_json(f_handler)
             elif os.path.isdir(config_file):
-                for dirs, sub_dirs, files in os.walk(config_file):
+                for _, _, files in os.walk(config_file):
                     for f_file in files:
                         f_path = config_file+f_file
                         if f_path.endswith('.json'):


### PR DESCRIPTION
settings dict is now available to be used in sensu plugins. 

Tested output
python nat_plugin.py (containing print self.settings['slack'])
{u'token': u'xxxxxxxxxxxxx', u'team_name': u'ABC', u'bot_name': u'sensu'}
