### PR TITLE
 Added ability to submit checks for a jit host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ coverage.xml
 docs/_build/
 
 MANIFEST
+
+
+
+
+venv

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ this:
     if __name__ == "__main__":
       f = MyCheck()
 
+## Remote (JIT) Checks
+
+To submit checks on behalf of another system, import push_event:
+
+    from sensu_plugin.pushevent import push_event
+
+Then use with:
+
+    push_event(source="a_remote_host", check_name="MyCheckName", exit_code=2, message="My check has failed")
+
+This will submit a check result (a failure) appearing to come from the remote host 'a_remote_host', for check 'MyCheckName'.
+
+The default assumption is that there is a local sensu client running on port 3030, but you can override this by passing in sensu_client_host and sensu_client_port parameters.
+
+The check submits the check in json format.  Arbitrary extra fields can be added, e.g.
+
+    push_event(source="a_remote_host", check_name="MyCheckName", exit_code=2, message="My check has failed", team="MyTeam")
+
 ## Metrics
 
 ### JSON

--- a/pylint.rc
+++ b/pylint.rc
@@ -35,7 +35,10 @@ load-plugins=
 # it should appear only once).
 #    R0201: *Method could be a function*
 #    C0111: *Missing doc string*
-disable=E1101,R0201,W0212,C0111
+#    R0903: *Too few public methods*
+#    E0602: *Locally disabling undefined-variable*
+#    R0204: *Redefinition of type from X to Y*
+disable=E1101,R0201,W0212,C0111,R0903,E0602,R0204
 
 
 
@@ -219,7 +222,7 @@ int-import-graph=
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=5
+max-args=6
 
 # Argument names that match this expression will be ignored. Default to name
 # with leading underscore

--- a/sensu_plugin/__init__.py
+++ b/sensu_plugin/__init__.py
@@ -5,3 +5,4 @@ from sensu_plugin.metric import SensuPluginMetricJSON
 from sensu_plugin.metric import SensuPluginMetricGraphite
 from sensu_plugin.metric import SensuPluginMetricStatsd
 from sensu_plugin.handler import SensuHandler
+import sensu_plugin.pushevent

--- a/sensu_plugin/pushevent.py
+++ b/sensu_plugin/pushevent.py
@@ -1,0 +1,33 @@
+import socket
+import json
+
+
+def push_event(sensu_client_host='127.0.0.1',
+               sensu_client_port=3030,
+               source=None,
+               check_name=None,
+               exit_code=None,
+               message=None,
+               **extra_vars):
+
+    for param in [source, check_name, exit_code, message]:
+        if param is None:
+            raise ValueError
+    message = {
+        "source":  source,
+        "name":    check_name,
+        "status":  exit_code,
+        "output":  message,
+        }
+    for key in extra_vars:
+        message[key] = extra_vars[key]
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    except socket.error:
+        sock.close()
+        raise
+    sock.connect((sensu_client_host, sensu_client_port))
+    sock.send(json.dumps(message))
+    if sock.recv(24) != "ok":
+        sock.close()
+        raise socket.error

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='sensu_plugin',
-    version='0.2.0',
+    version='0.3.0',
     author='S. Zachariah Sprackett',
     author_email='zac@sprackett.com',
     packages=['sensu_plugin', 'sensu_plugin.test'],


### PR DESCRIPTION
 JIT (Just-in-time) hosts are (often) virtual hosts used in the cases where for whatever reason a host check is submitted on behalf of another host this could be for centralised checks, or for remote checks of a system that cannot run sensu itself (e.g. a switch, or similar).

This adds the ability to submit JIT checks from within a sensu-plugin check.
