### PR TITLE
[DISCUSSION] Merge feat/handler_support

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,3 +3,4 @@ nose
 pep8
 pylint
 coverage
+requests

--- a/sensu_plugin/handler.py
+++ b/sensu_plugin/handler.py
@@ -6,16 +6,206 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
+from __future__ import print_function
+import os
+import sys
+import requests
+try:
+    from urlparse import urlparse
+except:
+    from urllib.parse import urlparse
+from utils import *
 
 class SensuHandler(object):
     def __init__(self):
-        pass
+        # Parse the stdin into a global event object
+        stdin = sys.stdin.read()
+        self.read_event(stdin)
+
+        # Prepare global settings
+        self.settings = get_settings()
+        self.api_settings = self.get_api_settings()
+
+        # Filter (deprecated) and handle
+        self.filter()
+        self.handle()
+    
+    def read_event(self, check_result):
+        '''
+        Convert the piped check result (json) into a global 'event' dict
+        '''
+        try:
+            self.event = json.loads(check_result)
+            self.event['occurrences'] = self.event.get('occurrences', 1)
+            self.event['check'] = self.event.get('check', {})
+            self.event['client'] = self.event.get('client', {})
+        except Exception as e:
+            print('error reading event: ' + e.message)
+            sys.exit(1)
 
     def handle(self):
-        pass
+        '''
+        Method that should be overwritten to provide handler logic.
+        '''
+        print('ignoring event -- no handler defined')
 
     def filter(self):
-        pass
+        '''
+        Filters exit the proccess if the event should not be handled.
+        
+        Filtering events is deprecated and will be removed in a future release.
+        '''
+
+        if self.deprecated_filtering_enabled():
+            print('warning: event filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin')
+            self.filter_disabled()
+            self.filter_silenced()
+            self.filter_dependencies()
+
+            if self.deprecated_occurrence_filtering_enabled():
+                print('warning: occurrence filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin')
+                self.filter_repeated()
+
+    def deprecated_filtering_enabled(self):
+        '''
+        Evaluates whether the event should be processed by any of the
+        filter methods in this library. Defaults to true,
+        i.e. deprecated filters are run by default.
+        
+        returns bool
+        '''
+        return self.event['check'].get('enable_deprecated_filtering', False)
+
+
+    def deprecated_occurrence_filtering_enabled(self):
+        '''
+        Evaluates whether the event should be processed by the
+        filter_repeated method. Defaults to true, i.e. filter_repeated
+        will filter events by default.
+
+        returns bool
+        '''
+
+        return self.event['check'].get('enable_deprecated_occurrence_filtering', False)
 
     def bail(self, msg):
-        pass
+        '''
+        Gracefully terminate with message
+        '''
+        client_name = self.event['client'].get('name', 'error:no-client-name')
+        check_name = self.event['client'].get('name', 'error:no-check-name')
+        print('{}: {}/{}'.format(msg, client_name, check_name))
+        sys.exit(0)
+
+    def get_api_settings(self):
+        '''
+        Return a hash of API settings derived first from ENV['SENSU_API_URL'] if set,
+        then Sensu config `api` scope if configured, and finally falling back to
+        to ipv4 localhost address on default API port.
+        
+        return dict
+        '''
+
+        SENSU_API_URL = os.environ.get('SENSU_API_URL')
+        if SENSU_API_URL:
+            uri = urlparse(SENSU_API_URL)
+            self.api_settings = {
+               'host': '{0}//{1}'.format(uri.scheme,uri.hostname),
+               'port': uri.port,
+               'user': uri.username,
+               'password': uri.password
+            }
+        else:
+            self.api_settings = self.settings.get('api',{})
+            self.api_settings['host'] = self.api_settings.get('host', '127.0.0.1')
+            self.api_settings['port'] = self.api_settings.get('port', 4567)
+    
+    # API requests
+    def api_request(method, path, blk):
+        if not hasattr(self, 'api_settings'):
+            ValueError('api.json settings not found')
+
+        if method.lower() == 'get':
+            _request = requests.get
+        elif method.lower() == 'post':
+            _request = requests.post
+      
+        domain = self.api_settings['host']
+        # TODO: http/https
+        uri = 'http://{}:{}{}'.format(domain, self.api_settings['port'], path)
+        if self.api_settings['user'] and self.api_settings['password']:
+            auth = (self.api_settings['user'], self.api_settings['password'])
+        else:
+            auth = ()
+        req = _request(uri, auth=auth)
+        return req
+       
+    def stash_exists(self, path):
+        return self.api_request('get', '/stash' + path).status_code == 200
+
+    def event_exists(self, client, check):
+        return self.api_request('get', '/events/' + client + '/' + check).status_code == 200
+
+    # Filters
+    def filter_disabled(self):
+        if self.event['check']['alert'] == False:
+            bail('alert disabled')
+
+    def filter_silenced(self):
+        stashes = [
+            ('client', '/silence/' + self.event['client']['name']),
+            ('check', '/silence/' + self.event['client']['name'] + '/' + self.event['check']['name']),
+            ('check', '/silence/all/' + self.event['check']['name'])
+        ]
+        for scope, path in stashes:
+            if stash_exists(path):
+                bail(scope + ' alerts silenced')
+            # TODO: Timeout for querying Sensu API?
+            #       More appropriate in the api_request method? 
+
+    def filter_dependencies(self):
+        dependencies = self.event['check'].get('dependencies', None)
+        if dependencies == None or not isinstance(dependencies, list):
+            return
+        for dependency in self.event['check']['dependencies']:
+            if len(str(dependency)) == 0:
+                continue
+            dependency_split = tuple(dependency.split('/'))
+            # If there's a dependency on a check from another client, then use
+            # that client name, otherwise assume same client.
+            if len(dependency_split) == 2:
+                client,check = dependency_split
+            else:
+                client = self.event['client']['name']
+                check = dependency_split[0]
+            if self.event_exists(client, check):
+                bail('check dependency event exists')
+
+
+    def filter_repeated(self):
+        defaults = {
+            'occurrences': 1,
+            'interval': 30,
+            'refresh': 1800
+        }
+
+        # Override defaults with anything defined in the settings 
+        if isinstance(self.settings['sensu_plugin'], dict):
+            defaults.update(settings['sensu_plugin'])
+        end
+
+        occurrences = int(self.event['check'].get('occurrences', defaults['occurrences']))
+        interval = int(self.event['check'].get('interval', defaults['interval']))
+        refresh = int(self.event['check'].get('refresh', defaults['refresh']))
+
+        if self.event['occurrences'] < occurrences:
+            bail('not enough occurrences')
+      
+        if self.event['occurrences'] > occurrences and self.event['action'] == 'create':
+            return
+        
+        number = int(refresh / interval)
+        if (number == 0) or ((self.event['occurrences'] - occurrences) % number == 0):
+            return
+
+        bail('only handling every ' + str(number) + ' occurrences')

--- a/sensu_plugin/handler.py
+++ b/sensu_plugin/handler.py
@@ -12,9 +12,10 @@ import sys
 import requests
 try:
     from urlparse import urlparse
-except:
+except ImportError:
     from urllib.parse import urlparse
 from utils import *
+
 
 class SensuHandler(object):
     def __init__(self):
@@ -29,7 +30,7 @@ class SensuHandler(object):
         # Filter (deprecated) and handle
         self.filter()
         self.handle()
-    
+
     def read_event(self, check_result):
         '''
         Convert the piped check result (json) into a global 'event' dict
@@ -52,18 +53,19 @@ class SensuHandler(object):
     def filter(self):
         '''
         Filters exit the proccess if the event should not be handled.
-        
         Filtering events is deprecated and will be removed in a future release.
         '''
 
         if self.deprecated_filtering_enabled():
-            print('warning: event filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin')
+            print('warning: event filtering in sensu-plugin is deprecated,' +
+                  'see http://bit.ly/sensu-plugin')
             self.filter_disabled()
             self.filter_silenced()
             self.filter_dependencies()
 
             if self.deprecated_occurrence_filtering_enabled():
-                print('warning: occurrence filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin')
+                print('warning: occurrence filtering in sensu-plugin is' +
+                      'deprecated, see http://bit.ly/sensu-plugin')
                 self.filter_repeated()
 
     def deprecated_filtering_enabled(self):
@@ -71,11 +73,10 @@ class SensuHandler(object):
         Evaluates whether the event should be processed by any of the
         filter methods in this library. Defaults to true,
         i.e. deprecated filters are run by default.
-        
+
         returns bool
         '''
         return self.event['check'].get('enable_deprecated_filtering', False)
-
 
     def deprecated_occurrence_filtering_enabled(self):
         '''
@@ -86,7 +87,8 @@ class SensuHandler(object):
         returns bool
         '''
 
-        return self.event['check'].get('enable_deprecated_occurrence_filtering', False)
+        return self.event['check'].get(
+            'enable_deprecated_occurrence_filtering', False)
 
     def bail(self, msg):
         '''
@@ -99,10 +101,10 @@ class SensuHandler(object):
 
     def get_api_settings(self):
         '''
-        Return a hash of API settings derived first from ENV['SENSU_API_URL'] if set,
-        then Sensu config `api` scope if configured, and finally falling back to
-        to ipv4 localhost address on default API port.
-        
+        Return a hash of API settings derived first from ENV['SENSU_API_URL']
+        if set, then Sensu config `api` scope if configured, and finally
+        falling back to to ipv4 localhost address on default API port.
+
         return dict
         '''
 
@@ -110,16 +112,18 @@ class SensuHandler(object):
         if SENSU_API_URL:
             uri = urlparse(SENSU_API_URL)
             self.api_settings = {
-               'host': '{0}//{1}'.format(uri.scheme,uri.hostname),
-               'port': uri.port,
-               'user': uri.username,
-               'password': uri.password
+                'host': '{0}//{1}'.format(uri.scheme, uri.hostname),
+                'port': uri.port,
+                'user': uri.username,
+                'password': uri.password
             }
         else:
-            self.api_settings = self.settings.get('api',{})
-            self.api_settings['host'] = self.api_settings.get('host', '127.0.0.1')
-            self.api_settings['port'] = self.api_settings.get('port', 4567)
-    
+            self.api_settings = self.settings.get('api', {})
+            self.api_settings['host'] = self.api_settings.get(
+                'host', '127.0.0.1')
+            self.api_settings['port'] = self.api_settings.get(
+                'port', 4567)
+
     # API requests
     def api_request(method, path, blk):
         if not hasattr(self, 'api_settings'):
@@ -129,7 +133,7 @@ class SensuHandler(object):
             _request = requests.get
         elif method.lower() == 'post':
             _request = requests.post
-      
+
         domain = self.api_settings['host']
         # TODO: http/https
         uri = 'http://{}:{}{}'.format(domain, self.api_settings['port'], path)
@@ -139,33 +143,37 @@ class SensuHandler(object):
             auth = ()
         req = _request(uri, auth=auth)
         return req
-       
+
     def stash_exists(self, path):
         return self.api_request('get', '/stash' + path).status_code == 200
 
     def event_exists(self, client, check):
-        return self.api_request('get', '/events/' + client + '/' + check).status_code == 200
+        return self.api_request('get',
+                                '/events/{}/{}'.format(client, check)
+                               ).status_code == 200
 
     # Filters
     def filter_disabled(self):
-        if self.event['check']['alert'] == False:
+        if self.event['check']['alert'] is False:
             bail('alert disabled')
 
     def filter_silenced(self):
         stashes = [
-            ('client', '/silence/' + self.event['client']['name']),
-            ('check', '/silence/' + self.event['client']['name'] + '/' + self.event['check']['name']),
-            ('check', '/silence/all/' + self.event['check']['name'])
+            ('client', '/silence/{}'.format(self.event['client']['name'])),
+            ('check', '/silence/{}/{}'.format(
+                self.event['client']['name'],
+                self.event['check']['name'])),
+            ('check', '/silence/all/{}'.format(self.event['check']['name']))
         ]
         for scope, path in stashes:
             if stash_exists(path):
                 bail(scope + ' alerts silenced')
             # TODO: Timeout for querying Sensu API?
-            #       More appropriate in the api_request method? 
+            #       More appropriate in the api_request method?
 
     def filter_dependencies(self):
         dependencies = self.event['check'].get('dependencies', None)
-        if dependencies == None or not isinstance(dependencies, list):
+        if dependencies is None or not isinstance(dependencies, list):
             return
         for dependency in self.event['check']['dependencies']:
             if len(str(dependency)) == 0:
@@ -174,13 +182,12 @@ class SensuHandler(object):
             # If there's a dependency on a check from another client, then use
             # that client name, otherwise assume same client.
             if len(dependency_split) == 2:
-                client,check = dependency_split
+                client, check = dependency_split
             else:
                 client = self.event['client']['name']
                 check = dependency_split[0]
             if self.event_exists(client, check):
                 bail('check dependency event exists')
-
 
     def filter_repeated(self):
         defaults = {
@@ -189,23 +196,28 @@ class SensuHandler(object):
             'refresh': 1800
         }
 
-        # Override defaults with anything defined in the settings 
+        # Override defaults with anything defined in the settings
         if isinstance(self.settings['sensu_plugin'], dict):
             defaults.update(settings['sensu_plugin'])
         end
 
-        occurrences = int(self.event['check'].get('occurrences', defaults['occurrences']))
-        interval = int(self.event['check'].get('interval', defaults['interval']))
-        refresh = int(self.event['check'].get('refresh', defaults['refresh']))
+        occurrences = int(self.event['check'].get(
+            'occurrences', defaults['occurrences']))
+        interval = int(self.event['check'].get(
+            'interval', defaults['interval']))
+        refresh = int(self.event['check'].get(
+            'refresh', defaults['refresh']))
 
         if self.event['occurrences'] < occurrences:
             bail('not enough occurrences')
-      
-        if self.event['occurrences'] > occurrences and self.event['action'] == 'create':
+
+        if (self.event['occurrences'] > occurrences and
+                self.event['action'] == 'create'):
             return
-        
+
         number = int(refresh / interval)
-        if (number == 0) or ((self.event['occurrences'] - occurrences) % number == 0):
+        if (number == 0 or
+                (self.event['occurrences'] - occurrences) % number == 0):
             return
 
         bail('only handling every ' + str(number) + ' occurrences')

--- a/sensu_plugin/utils/__init__.py
+++ b/sensu_plugin/utils/__init__.py
@@ -1,48 +1,53 @@
 import os
 import json
 
+
 def config_files():
-  SENSU_LOADED_TEMPFILE = os.environ.get('SENSU_LOADED_TEMPFILE')
-  SENSU_CONFIG_FILES = os.environ.get('SENSU_CONFIG_FILES')
-  if SENSU_LOADED_TEMPFILE and os.path.isfile(SENSU_LOADED_TEMPLATE):
-    with open(SENSU_LOADED_TEMPLATE, 'r') as template:
-      contents = template.read()
-      return contents.split(':')
-  elif SENSU_CONFIG_FILES:
-    return SENSU_CONFIG_FILES.split(':')
-  else:
-    files = ['/etc/sensu/config.json']
-    [files.append('/etc/sensu/conf.d/' + filename) for filename in os.listdir('/etc/sensu/conf.d') if os.path.splitext(filename)[1] == '.json']
-    return files
+    SENSU_LOADED_TEMPFILE = os.environ.get('SENSU_LOADED_TEMPFILE')
+    SENSU_CONFIG_FILES = os.environ.get('SENSU_CONFIG_FILES')
+    if SENSU_LOADED_TEMPFILE and os.path.isfile(SENSU_LOADED_TEMPLATE):
+        with open(SENSU_LOADED_TEMPLATE, 'r') as template:
+            contents = template.read()
+            return contents.split(':')
+    elif SENSU_CONFIG_FILES:
+        return SENSU_CONFIG_FILES.split(':')
+    else:
+        files = ['/etc/sensu/config.json']
+        [files.append('/etc/sensu/conf.d/{}'.format(filename))
+         for filename in os.listdir('/etc/sensu/conf.d')
+         if os.path.splitext(filename)[1] == '.json']
+        return files
+
 
 def get_settings():
-  settings = {}
-  for config_file in config_files():
-    config_contents = load_config(config_file)
-    if config_contents != None:
-      settings = deep_merge(settings, config_contents)
-  return settings 
+    settings = {}
+    for config_file in config_files():
+        config_contents = load_config(config_file)
+        if config_contents is not None:
+            settings = deep_merge(settings, config_contents)
+    return settings
+
 
 def load_config(filename):
-  try:
-    with open(filename, 'r') as config_file:
-      return json.loads(config_file.read())
-  except:
-    {}
+    try:
+        with open(filename, 'r') as config_file:
+            return json.loads(config_file.read())
+    except FileNotFoundError:
+        {}
+
 
 def deep_merge(dict_one, dict_two):
-  merged = dict_one.copy()
-  for key,value in dict_two.items():
-    # value is equivalent to dict_two[key]
-    if (key in dict_one and
-        isinstance(dict_one[key], dict) and
-        isinstance(value, dict)):
-      merged[key] = deep_merge(dict_one[key], value)
-    elif (key in dict_one and
-          isinstance(dict_one[key], list) and 
-          isinstance(value, list)):
-      merged[key] = list(set(dict_one[key] + value))
-    else:
-      merged[key] = value
-  return merged
-
+    merged = dict_one.copy()
+    for key, value in dict_two.items():
+        # value is equivalent to dict_two[key]
+        if (key in dict_one and
+            isinstance(dict_one[key], dict) and
+                isinstance(value, dict)):
+            merged[key] = deep_merge(dict_one[key], value)
+        elif (key in dict_one and
+              isinstance(dict_one[key], list) and
+              isinstance(value, list)):
+            merged[key] = list(set(dict_one[key] + value))
+        else:
+            merged[key] = value
+    return merged

--- a/sensu_plugin/utils/__init__.py
+++ b/sensu_plugin/utils/__init__.py
@@ -1,25 +1,34 @@
+'''
+Utilities for loading config files, etc.
+'''
+
 import os
 import json
 
 
 def config_files():
-    SENSU_LOADED_TEMPFILE = os.environ.get('SENSU_LOADED_TEMPFILE')
-    SENSU_CONFIG_FILES = os.environ.get('SENSU_CONFIG_FILES')
-    if SENSU_LOADED_TEMPFILE and os.path.isfile(SENSU_LOADED_TEMPLATE):
-        with open(SENSU_LOADED_TEMPLATE, 'r') as template:
-            contents = template.read()
+    '''
+    Get list of currently used config files.
+    '''
+    sensu_loaded_tempfile = os.environ.get('SENSU_LOADED_TEMPFILE')
+    sensu_config_files = os.environ.get('SENSU_CONFIG_FILES')
+    if sensu_loaded_tempfile and os.path.isfile(sensu_loaded_tempfile):
+        with open(sensu_loaded_tempfile, 'r') as tempfile:
+            contents = tempfile.read()
             return contents.split(':')
-    elif SENSU_CONFIG_FILES:
-        return SENSU_CONFIG_FILES.split(':')
+    elif sensu_config_files:
+        return sensu_config_files.split(':')
     else:
         files = ['/etc/sensu/config.json']
-        [files.append('/etc/sensu/conf.d/{}'.format(filename))
-         for filename in os.listdir('/etc/sensu/conf.d')
-         if os.path.splitext(filename)[1] == '.json']
-        return files
+        return [files.append('/etc/sensu/conf.d/{}'.format(filename))
+                for filename in os.listdir('/etc/sensu/conf.d')
+                if os.path.splitext(filename)[1] == '.json']
 
 
 def get_settings():
+    '''
+    Get all currently loaded settings.
+    '''
     settings = {}
     for config_file in config_files():
         config_contents = load_config(config_file)
@@ -29,19 +38,25 @@ def get_settings():
 
 
 def load_config(filename):
+    '''
+    Read contents of config file.
+    '''
     try:
         with open(filename, 'r') as config_file:
             return json.loads(config_file.read())
-    except FileNotFoundError:
-        {}
+    except IOError:
+        pass
 
 
 def deep_merge(dict_one, dict_two):
+    '''
+    Deep merge two dicts.
+    '''
     merged = dict_one.copy()
     for key, value in dict_two.items():
         # value is equivalent to dict_two[key]
         if (key in dict_one and
-            isinstance(dict_one[key], dict) and
+                isinstance(dict_one[key], dict) and
                 isinstance(value, dict)):
             merged[key] = deep_merge(dict_one[key], value)
         elif (key in dict_one and

--- a/sensu_plugin/utils/__init__.py
+++ b/sensu_plugin/utils/__init__.py
@@ -1,0 +1,48 @@
+import os
+import json
+
+def config_files():
+  SENSU_LOADED_TEMPFILE = os.environ.get('SENSU_LOADED_TEMPFILE')
+  SENSU_CONFIG_FILES = os.environ.get('SENSU_CONFIG_FILES')
+  if SENSU_LOADED_TEMPFILE and os.path.isfile(SENSU_LOADED_TEMPLATE):
+    with open(SENSU_LOADED_TEMPLATE, 'r') as template:
+      contents = template.read()
+      return contents.split(':')
+  elif SENSU_CONFIG_FILES:
+    return SENSU_CONFIG_FILES.split(':')
+  else:
+    files = ['/etc/sensu/config.json']
+    [files.append('/etc/sensu/conf.d/' + filename) for filename in os.listdir('/etc/sensu/conf.d') if os.path.splitext(filename)[1] == '.json']
+    return files
+
+def get_settings():
+  settings = {}
+  for config_file in config_files():
+    config_contents = load_config(config_file)
+    if config_contents != None:
+      settings = deep_merge(settings, config_contents)
+  return settings 
+
+def load_config(filename):
+  try:
+    with open(filename, 'r') as config_file:
+      return json.loads(config_file.read())
+  except:
+    {}
+
+def deep_merge(dict_one, dict_two):
+  merged = dict_one.copy()
+  for key,value in dict_two.items():
+    # value is equivalent to dict_two[key]
+    if (key in dict_one and
+        isinstance(dict_one[key], dict) and
+        isinstance(value, dict)):
+      merged[key] = deep_merge(dict_one[key], value)
+    elif (key in dict_one and
+          isinstance(dict_one[key], list) and 
+          isinstance(value, list)):
+      merged[key] = list(set(dict_one[key] + value))
+    else:
+      merged[key] = value
+  return merged
+


### PR DESCRIPTION
Alright, it took me a little while but I converted the Ruby version. **Disclaimer:** I am not a developer, so if this code eats your infrastructure and runs over you dog, don't blame me.

This is working from my rough tests, barring one big known flaw at the moment! Currently `utils/__init__.py` contains the `config_files()` function which scrapes local config files, for use in configuring handlers - However, this only looks in `/etc/sensu/config.json` and `/etc/sensu/conf.d/*.json` at the minute.

In my Sensu setup, I have an `/etc/sensu/handlers` directory which is configured by passing in `-e /etc/sensu/handlers` to `sensu-server`, which would mean all of my handler configs would be missed (Although, I'm not sure why the Ruby `sensu-plugin` isn't missing the settings?).

I was wondering what the best method of including necessary directories is, as if we just hard-coded some directory paths, it could bite some unsuspecting users in the arse (Violates POLA), but alternatively, including `/etc/sensu/**/.json` could be dangerous or cause configs to be overwritten. The ideal situation would be to see which paths Sensu is currently using, without having to scrape the process tree.

Any ideas?