### PR TITLE
Corrects vars in bail()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- Fixes `client_name` in `bail()` as it was using an incorrect path within `event` dict (@absolutejam)
 
 # [0.4.1]
 ## Fixed

--- a/sensu_plugin/handler.py
+++ b/sensu_plugin/handler.py
@@ -103,8 +103,8 @@ class SensuHandler(object):
         '''
         Gracefully terminate with message
         '''
-        client_name = self.event.get('client', 'error:no-client-name')
-        check_name = self.event['client'].get('name', 'error:no-check-name')
+        client_name = self.event['client'].get('name', 'error:no-client-name')
+        check_name = self.event['check'].get('name', 'error:no-check-name')
         print('{}: {}/{}'.format(msg, client_name, check_name))
         sys.exit(0)
 


### PR DESCRIPTION
I went against the knowledge of people smarter than me and changed where `client_name` was looking in the `event` dict when porting from Ruby, as I thought it was incorrect. It turns out that I was actually testing the handler with incorrect data,which lead to my bad conclusion and @cwjohnston has now put me on the straight and narrow. I've re-ran some checks of my handler and so far nothing else has been affected by the bad test data I used initially, and using the right event data for a check result has lead to me closing another PR as it's no longer unnecessary (Free features!).

This highlights the fact that we need more testing and CI, as per Slack discussion. Hopefully we can get the ball rolling with that in another PR shortly :smile: 

*This will might need rebasing if the other bugfix PR is merged?*