### PR TITLE
[WIP] Discussion - Helper functions

### DIFF
--- a/sensu_plugin/tests/example_configs.py
+++ b/sensu_plugin/tests/example_configs.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+def example_settings():
+    settings = '''
+{
+  "redis": {
+    "reconnect_on_error": false,
+    "auto_reconnect": true,
+    "host": "redis",
+    "db": 0,
+    "port": 6379
+  },
+  "api": {
+    "bind": "0.0.0.0",
+    "host": "api",
+    "port": 4567
+  },
+  "transport": {
+    "reconnect_on_error": true,
+    "name": "redis"
+  },
+  "checks": {},
+  "handlers": {}
+}
+'''
+
+    return settings
+
+
+def example_check_result():
+    check_result = '''
+{
+  "id": "ef6b87d2-1f89-439f-8bea-33881436ab90",
+  "action": "create",
+  "timestamp": 1460172826,
+  "occurrences": 2,
+  "check": {
+    "type": "standard",
+    "total_state_change": 11,
+    "history": ["0", "0", "1", "1", "2", "2"],
+    "status": 2,
+    "output": "No keepalive sent from client for 230 seconds (>=180)",
+    "executed": 1460172826,
+    "issued": 1460172826,
+    "name": "keepalive",
+    "thresholds": {
+      "critical": 180,
+      "warning": 120
+    }
+  },
+  "client": {
+    "timestamp": 1460172596,
+    "version": "1.1.0",
+    "socket": {
+      "port": 3030,
+      "bind": "127.0.0.1"
+    },
+    "subscriptions": [
+      "production"
+    ],
+    "environment": "development",
+    "address": "127.0.0.1",
+    "name": "client-01"
+  }
+}
+'''
+
+    return check_result

--- a/sensu_plugin/tests/test_utils.py
+++ b/sensu_plugin/tests/test_utils.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+import unittest
+import nose
+from unittest.mock import patch
+
+# Import sensu_plugin with relative path
+import sys
+import os
+import json
+
+# Alter path and import modules
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../../')
+from sensu_plugin.utils import *
+from example_configs import example_settings, example_check_result
+
+# Currently just a single example check result
+check_result = example_check_result()
+check_result_dict = json.loads(check_result)
+settings = example_settings()
+settings_dict = json.loads(settings)
+
+class TestSensuUtils(unittest.TestCase):
+    maxDiff = None
+
+    def test_recurse_dict(self):
+        # Using example check result
+        thresholds_critical = recurse_dict(check_result_dict,
+                                         'check.thresholds.critical')
+
+        self.assertEqual(thresholds_critical, 180)
+
+        with self.assertRaises(ValueError):
+            recurse_dict(check_result_dict, 'foo')
+
+if __name__ == '__main__':
+    # Run with nose directly
+    module_name = sys.modules[__name__].__file__
+
+    result = nose.run(argv=[
+       sys.argv[0],
+       module_name,
+       '-v',
+       '--with-coverage',
+       '--cover-min-percentage=25',
+       '--cover-erase',
+       '--cover-html',
+       '--cover-html-dir', './sensu_plugin/test/report',
+       '--exe'
+    ])

--- a/sensu_plugin/utils.py
+++ b/sensu_plugin/utils.py
@@ -66,3 +66,34 @@ def deep_merge(dict_one, dict_two):
         else:
             merged[key] = value
     return merged
+
+
+def recurse_dict(data, path, raise_exception=True, first=True):
+    '''
+    Get a value from within a nested dict, using a dot-separated string as
+    the path, eg. 'myconfig.settings.foo' is equivalent to
+    { 'myconfig': { 'settings': { 'foo': 'bar' } } } and would return 'bar'.
+    '''
+
+    # TODO: This feels dirty
+    if first == True:
+        path = path.split('.')
+        path.reverse()
+
+    # Take the top-most level
+    current_level = path.pop()
+    next_level = data.get(current_level)
+
+    if not next_level:
+        if raise_exception:
+            error_msg = "could not find key '{}'".format(current_level)
+            raise ValueError(error_msg)
+        else:
+            return None
+
+    if len(path) > 1:
+        ret = recurse_dict(next_level, path, first=False)
+        return ret
+    # Get the last remaining tem
+    elif len(path) == 1:
+        return next_level.get(path[0])

--- a/sensu_plugin/utils.py
+++ b/sensu_plugin/utils.py
@@ -68,7 +68,7 @@ def deep_merge(dict_one, dict_two):
     return merged
 
 
-def recurse_dict(data, path, raise_exception=True, first=True):
+def recurse_dict(data, path, first=True):
     '''
     Get a value from within a nested dict, using a dot-separated string as
     the path, eg. 'myconfig.settings.foo' is equivalent to
@@ -85,11 +85,8 @@ def recurse_dict(data, path, raise_exception=True, first=True):
     next_level = data.get(current_level)
 
     if not next_level:
-        if raise_exception:
-            error_msg = "could not find key '{}'".format(current_level)
-            raise ValueError(error_msg)
-        else:
-            return None
+        error_msg = "could not find key '{}'".format(current_level)
+        raise ValueError(error_msg)
 
     if len(path) > 1:
         ret = recurse_dict(next_level, path, first=False)
@@ -97,3 +94,19 @@ def recurse_dict(data, path, raise_exception=True, first=True):
     # Get the last remaining tem
     elif len(path) == 1:
         return next_level.get(path[0])
+
+
+def get_config(path, *configs):
+    '''
+    Find a dict item using dot notation, falling back to the next dict in a
+    list if the item is not found. This leverages the recurse_dict function.
+    '''
+    found = None
+    for config in configs:
+        try:
+            found = recurse_dict(config, path)
+            break
+        except ValueError as ve:
+            continue
+
+    return found


### PR DESCRIPTION
I've got a few helper functions that I've relied upon a couple of times now and wondered what you thought of including them into utils, along with documentation? Don't mean to bloat, but I feel like we could make creating handlers easier if we provided some higher level functions.

Please bear in mind, these are **very** rough and need better testing; I just wanted to get a PR logged before much overdue sleep :zzz: 

`get_config` 

This lets me define a list of dicts to check for a config value, allowing me to check the check definition, client settings, then server settings for a config value, short-circuiting at the first instance found. This provides a level of optional granularity to handler configs, as a more generic value can be defined higher up the list (eg. in server config) and individual overrides can be applied per check by adding the same value in the check definitions. An example of this is in my SaltStack handler which I'll link later.

`recurse_dict`

This lets me specify a dict path in dot notation, so the following:
```
{ "foo": { "bar": { "baz: True } } }
```
becomes `foo.bar.baz`. This is used in the above function and I'm using it in my (WIP) Google Sheets handler to allow inclusion of different config vars to be included in the handler output.

Let me know what you think of including these (once tested & refined), but also the general idea of helper functions. It could be that my use case is very specific and only I'd need to use these, but I'm finding myself needing them more and more as I make my handlers more dynamic.

Cheers!