### PR TITLE
add handler support for command line arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 # [Unreleased]
+## Added
+- handlers can now process commandline arguments (@barryorourke)
 
 # [0.4.5]
 ## Fixed
-- fix read event exception raise @oboukili
+- fix read event exception raise (@oboukili)
 
 # [0.4.4]
 ## Fixed

--- a/pylint.rc
+++ b/pylint.rc
@@ -40,7 +40,8 @@ load-plugins=
 #    R0204: *Redefinition of type from X to Y*
 #    W0221: arguments-differ
 # BOR-TODO: look into W0211 more
-disable=E1101,R0201,W0212,C0111,R0903,E0602,R0204,W0221
+# BOR-TODO: remove R0205 when we drop python 2.7 support
+disable=E1101,R0201,W0212,C0111,R0903,E0602,R0204,W0221,R0205
 
 
 

--- a/sensu_plugin/handler.py
+++ b/sensu_plugin/handler.py
@@ -12,6 +12,7 @@ python-based Sensu handlers.
 '''
 
 from __future__ import print_function
+import argparse
 import os
 import sys
 import json
@@ -35,6 +36,12 @@ class SensuHandler(object):
         # Prepare global settings
         self.settings = get_settings()
         self.api_settings = self.get_api_settings()
+
+        # Prepare command line arguments
+        self.parser = argparse.ArgumentParser()
+        if hasattr(self, 'setup'):
+            self.setup()
+        (self.options, self.remain) = self.parser.parse_known_args()
 
         # Filter (deprecated) and handle
         self.filter()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='sensu_plugin',
-    version='0.4.5',
+    version='0.4.6',
     author='Sensu-Plugins and contributors',
     author_email='sensu-users@googlegroups.com',
     packages=['sensu_plugin', 'sensu_plugin.test'],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='sensu_plugin',
-    version='0.4.6',
+    version='0.4.5',
     author='Sensu-Plugins and contributors',
     author_email='sensu-users@googlegroups.com',
     packages=['sensu_plugin', 'sensu_plugin.test'],


### PR DESCRIPTION
This adds support for passing command line arguments to handlers and is a prerequisite of  https://github.com/sensu-plugins/sensu-plugin-python/issues/46