### PR TITLE
Sensu Handler shim for Sensu 2.0 event data.

### DIFF
--- a/pylint.rc
+++ b/pylint.rc
@@ -42,7 +42,7 @@ load-plugins=
 #    W0221: arguments-differ
 # BOR-TODO: look into W0211 more
 # BOR-TODO: remove R0205 when we drop python 2.7 support
-disable=E1101,R0201,W0212,C0111,R0903,E0602,R0204,W0221,R0205
+disable=E1101,R0201,W0212,C0111,R0903,E0602,R0204,W0221,R0205,R0912
 
 
 

--- a/sensu_plugin/tests/example_configs.py
+++ b/sensu_plugin/tests/example_configs.py
@@ -112,8 +112,96 @@ def example_check_result_v2():
       }
     ],
     "status": 0
-  }
+  },
+  "occurrences": 1
 }
 '''
 
+    return check_result
+
+
+def example_check_result_v2_mapped():
+    check_result = '''
+{
+  "action": "create",
+  "check": {
+    "history": [
+      "0",
+      "1",
+      "2",
+      "3",
+      "0"
+    ],
+    "history_v2": [
+      {
+        "executed": 0,
+        "status": 0
+      },
+      {
+        "executed": 1,
+        "status": 1
+      },
+      {
+        "executed": 2,
+        "status": 2
+      },
+      {
+        "executed": 3,
+        "status": 3
+      },
+      {
+        "executed": 4,
+        "status": 0
+      }
+    ],
+    "name": "test_check",
+    "output": "test_output",
+    "proxy_entity_id": "test_proxy",
+    "source": "test_proxy",
+    "state": "failing",
+    "status": 0,
+    "subscribers": [
+      "sub1",
+      "sub2",
+      "sub3"
+    ],
+    "subscriptions": [
+      "sub1",
+      "sub2",
+      "sub3"
+    ],
+    "total_state_change": 4
+  },
+  "client": {
+    "id": "test_entity",
+    "name": "test_entity",
+    "subscribers": [
+      "sub1",
+      "sub2",
+      "sub3"
+    ],
+    "subscriptions": [
+      "sub1",
+      "sub2",
+      "sub3"
+    ]
+  },
+  "entity": {
+    "id": "test_entity",
+    "name": "test_entity",
+    "subscribers": [
+      "sub1",
+      "sub2",
+      "sub3"
+    ],
+    "subscriptions": [
+      "sub1",
+      "sub2",
+      "sub3"
+    ]
+  },
+  "occurrences": 1,
+  "v2_event_mapped_into_v1": true
+}
+'''
     return check_result

--- a/sensu_plugin/tests/example_configs.py
+++ b/sensu_plugin/tests/example_configs.py
@@ -65,3 +65,55 @@ def example_check_result():
 '''
 
     return check_result
+
+
+def example_check_result_v2():
+    check_result = '''
+{
+  "entity": {
+    "id": "test_entity",
+    "subscriptions": [
+      "sub1",
+      "sub2",
+      "sub3"
+    ]
+  },
+  "check": {
+    "name": "test_check",
+    "output": "test_output",
+    "subscriptions": [
+      "sub1",
+      "sub2",
+      "sub3"
+    ],
+    "proxy_entity_id": "test_proxy",
+    "total_state_change": 4,
+    "state":"failing",
+    "history": [
+      {
+        "status": 0,
+        "executed": 0
+      },
+      {
+        "status": 1,
+        "executed": 1
+      },
+      {
+        "status": 2,
+        "executed": 2
+      },
+      {
+        "status": 3,
+        "executed": 3
+      },
+      {
+        "status":0,
+        "executed":4
+      }
+    ],
+    "status": 0
+  }
+}
+'''
+
+    return check_result

--- a/sensu_plugin/tests/test_util.py
+++ b/sensu_plugin/tests/test_util.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import json
+
+from sensu_plugin.tests.example_configs import example_check_result_v2
+from sensu_plugin.tests.example_configs import example_check_result_v2_mapped
+
+from sensu_plugin.utils import map_v2_event_into_v1
+
+
+def test_map_v2_event_into_v1():
+    event = json.loads(example_check_result_v2())
+    expected = json.loads(example_check_result_v2_mapped())
+
+    result = map_v2_event_into_v1(event)
+
+    assert result == expected

--- a/sensu_plugin/utils.py
+++ b/sensu_plugin/utils.py
@@ -112,11 +112,10 @@ def map_v2_event_into_v1(event):
         else:
             state = "unknown::2.0_event"
 
-        if "action" not in event:
-            if state.lower() in action_state_mapping:
-                event['action'] = action_state_mapping[state.lower()]
-            else:
-                event['action'] = state
+        if "action" not in event and state.lower() in action_state_mapping:
+            event['action'] = action_state_mapping[state.lower()]
+        else:
+            event['action'] = state
 
         # Mimic 1.4 event history based on 2.0 event history
         if "history" in event['check']:

--- a/sensu_plugin/utils.py
+++ b/sensu_plugin/utils.py
@@ -81,9 +81,6 @@ def map_v2_event_into_v1(event):
     if "v2_event_mapped_into_v1" in event:
         return event
 
-    # convert the event into a dict
-    event = json.loads(event)
-
     # Trigger mapping code if enity exists and client does not
     if not bool(event.get('client')) and "entity" in event:
         event['client'] = event['entity']
@@ -134,4 +131,4 @@ def map_v2_event_into_v1(event):
         event['v2_event_mapped_into_v1'] = True
 
     # return the updated event
-    return json.dumps(event)
+    return event

--- a/sensu_plugin/utils.py
+++ b/sensu_plugin/utils.py
@@ -68,3 +68,63 @@ def deep_merge(dict_one, dict_two):
         else:
             merged[key] = value
     return merged
+
+
+def map_v2_event_into_v1(event):
+    '''
+    Helper method to convert Sensu 2.x event into Sensu 1.x event.
+    '''
+
+    # return the event if it has already been mapped
+    if "v2_event_mapped_into_v1" in event:
+        return event
+
+    # convert the event into a dict
+    event = json.loads(event)
+
+    # Trigger mapping code if enity exists and client does not
+    if "client" not in event and "entity" in event:
+        event['client'] = event['entity']
+
+        # Fill in missing client attributes
+        if "name" not in event['client']:
+            event['client']['name'] = event['entity']['id']
+
+        if "subscribers" not in event['client']:
+            event['client']['subscribers'] = event['entity']['subscriptions']
+
+        # Fill in renamed check attributes expected in 1.4 event
+        if "subscribers" not in event['check']:
+            event['check']['subscribers'] = event['check']['subscriptions']
+
+        if "source" not in event['check']:
+            event['check']['source'] = event['check']['proxy_entity_id']
+
+        # Mimic 1.4 event action based on 2.0 event state
+        #  action used in logs and fluentd plugins handlers
+        action_state_mapping = {'flapping': 'flapping', 'passing': 'resolve',
+                                'failing': 'create'}
+
+        if "state" in event['check']:
+            state = event['check']['state']
+        else:
+            state = "unknown::2.0_event"
+
+        if "action" not in event:
+            event['action'] = action_state_mapping[state.lower()]
+
+        # Mimic 1.4 event history based on 2.0 event history
+        if "history" in event['check']:
+            # save the original history
+            history_v2 = event['check']['history']
+            event['check']['history_v2'] = history_v2
+            legacy_history = []
+            for history in event['check']['history']:
+                legacy_history.append(str(history['status']))
+            event['check']['history'] = legacy_history
+
+        # Setting flag indicating this function has already been called
+        event['v2_event_mapped_into_v1'] = True
+
+    # return the updated event
+    return json.dumps(event)


### PR DESCRIPTION
The event data model changed in Sensu 2.0, so to make it possible to continue to use the community managed handlers a quick mapping back into Sensu 1.4 event JSON representation can be performed.

This is a port of the recent PR merged into sensu-plugin gem (https://github.com/sensu-plugins/sensu-plugin/pull/190).