### PR TITLE
make get_settings() compatible with sensu 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 # [Unreleased]
+- Make get_settings() sensu 2.0 compatible. (@barryorourke)
 
 # [0.7.0]
 ## Added

--- a/sensu_plugin/tests/test_utils.py
+++ b/sensu_plugin/tests/test_utils.py
@@ -26,12 +26,16 @@ def test_get_settings_no_files():
         assert settings == {}
 
 
-def test_get_settings_with_file():
+@patch('os.path.isfile')
+@patch('os.path.isdir')
+def test_get_settings_with_file(mock_isfile, mock_isdir):
     '''
     Test the get settings method with one file.
     '''
     test_json = '{"test": { "key": "value"}}'
     mocked_open = mock_open(read_data=test_json)
+    mock_isfile.return_value = True
+    mock_isdir.return_value = True
     with patch('os.listdir') as mocked_listdir:
         try:
             with patch("builtins.open", mocked_open):

--- a/sensu_plugin/utils.py
+++ b/sensu_plugin/utils.py
@@ -14,6 +14,8 @@ def config_files():
     '''
     sensu_loaded_tempfile = os.environ.get('SENSU_LOADED_TEMPFILE')
     sensu_config_files = os.environ.get('SENSU_CONFIG_FILES')
+    sensu_v1_config = '/etc/sensu/config.json'
+    sensu_v1_confd = '/etc/sensu/conf.d'
     if sensu_loaded_tempfile and os.path.isfile(sensu_loaded_tempfile):
         with open(sensu_loaded_tempfile, 'r') as tempfile:
             contents = tempfile.read()
@@ -21,11 +23,15 @@ def config_files():
     elif sensu_config_files:
         return sensu_config_files.split(':')
     else:
-        files = ['/etc/sensu/config.json']
-        filenames = [f for f in os.listdir('/etc/sensu/conf.d')
-                     if os.path.splitext(f)[1] == '.json']
-        for filename in filenames:
-            files.append('/etc/sensu/conf.d/{}'.format(filename))
+        files = []
+        filenames = []
+        if os.path.isfile(sensu_v1_config):
+            files = [sensu_v1_config]
+        if os.path.isdir(sensu_v1_confd):
+            filenames = [f for f in os.listdir(sensu_v1_confd)
+                         if os.path.splitext(f)[1] == '.json']
+            for filename in filenames:
+                files.append('{}/{}'.format(sensu_v1_confd, filename))
         return files
 
 


### PR DESCRIPTION
get_settings() assumes the existence of /etc/sensu/config.json and /etc/sensu/conf.d, these are not present by default when using Sensu 2.0.